### PR TITLE
Univalent Type Theory ?

### DIFF
--- a/cortona2020/index.html
+++ b/cortona2020/index.html
@@ -30,7 +30,7 @@
     <h2>Overview</h2>
     
     <p>
-      Univalent Type Theory is an emerging field of mathematics that studies
+      Homotopy Type Theory and Univalent Mathematics are emerging fields of mathematics that study
       a fruitful relationship between homotopy theory and (dependent) type
       theory. 
       This relation plays a crucial role in Voevodsky's program of Univalent


### PR DESCRIPTION
Section Overview talks about Univalent Type Theory.
I thought it was an error until I found with google the discussion in https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/ 

However, Univalent Type Theory is weird because the title of the school is Univalent Mathematics.
Also it doesn't sound very much "mathematical".

I propose to replace with "Homotopy Type Theory and Univalent Mathematics" which has been used already in several occasion.

But tell me if you feel to do something different.